### PR TITLE
Fixed one test missing URL, removed file - from tests

### DIFF
--- a/tests/test_apix.py
+++ b/tests/test_apix.py
@@ -1,6 +1,4 @@
-import os
 from subprocess import check_output
-import pytest
 
 # subset of ~20 example invokations from the API-explorer page  (all GET)
 # http://www.mg-rast.org/mgmain.html?mgpage=api 


### PR DESCRIPTION
This will probably quell the apparently false-positive test_utf8_metadata_export errors by removing "file -" from the testing suite, using python to validate utf8 format and json. 